### PR TITLE
fix: update homepage when favorite / recent collections change

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -8,7 +8,7 @@ const categorized = ref(getIconList(categorySearch.value))
 
 let categorizeDebounceTimer: NodeJS.Timeout | null = null
 
-watch(categorySearch, (newVal) => {
+watch([categorySearch, favoritedCollections, recentCollections], ([newVal]) => {
   if (categorizeDebounceTimer)
     clearTimeout(categorizeDebounceTimer)
   categorizeDebounceTimer = setTimeout(() => {


### PR DESCRIPTION
Just noticed that deleting a collection from recent list does not trigger UI update, here's the quick fix.