### PR TITLE
feat: return shorter data url if possible

### DIFF
--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -1,4 +1,5 @@
 import { buildIcon, loadIcon } from 'iconify-icon'
+import { encodeSvgForCss } from '@iconify/utils'
 import { getTransformedId } from '../store'
 import Base64 from './base64'
 import { HtmlToJSX } from './htmlToJsx'
@@ -211,6 +212,16 @@ export function ${name}(props) {
   return prettierCode(code, 'babel-ts')
 }
 
+export function SvgToDataURL(svg: string) {
+  const url = `data:image/svg+xml;base64,${Base64.encode(svg)}`
+  const percentURL = `data:image/svg+xml,${encodeSvgForCss(svg)}`
+
+  if (percentURL.length < url.length)
+    return percentURL
+
+  return url
+}
+
 export async function getIconSnippet(icon: string, type: string, snippet = true, color = 'currentColor'): Promise<string | undefined> {
   if (!icon)
     return
@@ -235,7 +246,7 @@ export async function getIconSnippet(icon: string, type: string, snippet = true,
     case 'svg-symbol':
       return await getSvgSymbol(icon, '32', color)
     case 'data_url':
-      return `data:image/svg+xml;base64,${Base64.encode(await getSvg(icon, undefined, color))}`
+      return SvgToDataURL(await getSvg(icon, undefined, color))
     case 'pure-jsx':
       return ClearSvg(await getSvg(icon, undefined, color))
     case 'jsx':

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -213,13 +213,10 @@ export function ${name}(props) {
 }
 
 export function SvgToDataURL(svg: string) {
-  const url = `data:image/svg+xml;base64,${Base64.encode(svg)}`
-  const percentURL = `data:image/svg+xml,${encodeSvgForCss(svg)}`
-
-  if (percentURL.length < url.length)
-    return percentURL
-
-  return url
+  const base64 = `data:image/svg+xml;base64,${Base64.encode(svg)}`
+  const plain = `data:image/svg+xml,${encodeSvgForCss(svg)}`
+  // Return the shorter of the two data URLs
+  return base64.length < plain.length ? base64 : plain
 }
 
 export async function getIconSnippet(icon: string, type: string, snippet = true, color = 'currentColor'): Promise<string | undefined> {


### PR DESCRIPTION
Concern: the result of `encodeSvgForCss()` intentionally escapes `"` (double quote) because it is then be used in generating the CSS `url("...")`. That is to say, the `'` (single quote) is not escaped.

There's a even more shorter algorithm which does not escace `<` and `"` `'` [in esbuild](https://github.com/evanw/esbuild/blob/main/internal/helpers/dataurl.go). The use case is to be assigned to `img.src` in JavaScript, like in React and Vue element props. I guess this is not a handy choice when I just want to copy and paste the url to CSS/HTML.