### PR TITLE
fix: code value cache on show

### DIFF
--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -210,7 +210,7 @@ const collection = computed(() => {
               {{ groupName }}
             </div>
             <div class="flex gap-1">
-              <template v-for="(snippet, type) in group" :key="type">
+              <template v-for="(snippet, type) in group" :key="`${icon}-${groupName}-${type}`">
                 <SnippetPreview
                   :icon="icon"
                   :snippet="snippet"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `code.value` seems to be cached by `type`, so the popover value doesn't change when only the icon changes.

<img width="869" alt="image" src="https://github.com/user-attachments/assets/660a1f93-7a86-492b-a49a-635f94dc9271" />


<img width="1257" alt="image" src="https://github.com/user-attachments/assets/9d85c449-b924-4898-a0d2-443237cf92d9" />


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
