### PR TITLE
fix: iconify URL parameter from 'query' to 'icon-filter'

### DIFF
--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -266,7 +266,7 @@ const collection = computed(() => {
           </div>
           <a
             v-if="collection" class="btn small mr-1 mb-1 opacity-75 inline-flex"
-            :href="`https://icon-sets.iconify.design/${collection.id}/?query=${icon.split(':')[1]}`" target="_blank"
+            :href="`https://icon-sets.iconify.design/${collection.id}/?icon-filter=${icon.split(':')[1]}`" target="_blank"
           >
             Iconify
           </a>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
![image](https://github.com/user-attachments/assets/e7d03658-2949-449d-9fa0-814ced1b9fc3)
This PR updates the URL used for linking to Iconify icon set pages `https://icon-sets.iconify.design/`.

The URL parameter `query` used for search icons (e.g., `https://icon-sets.iconify.design/mingcute/?query=crystal-ball-fill`) has been observed to be deprecated on the Iconify website.
Please check the picture below

![image](https://github.com/user-attachments/assets/9d2e8fce-d44e-4c82-bb5b-1b9420268c00)

_No search results are filtered._

The site now uses the `icon-filter` parameter for the same functionality (e.g., `https://icon-sets.iconify.design/mingcute/?icon-filter=crystal-ball-fill`).

![image](https://github.com/user-attachments/assets/081b7485-de73-4b70-a339-ee4b0baeddae)



### Linked Issues
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This is a really great project, thank you!
The only minor issue I noticed was the outdated Iconify link, which prompted me to open this PR.


