### PR TITLE
feat: allow download missing frameworks zip from bag

### DIFF
--- a/src/components/Bag.vue
+++ b/src/components/Bag.vue
@@ -87,6 +87,21 @@ async function PackSvgs(type: PackType = 'svg') {
         <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('tsx')">
           React<sup class="opacity-50 -mr-1">TS</sup>
         </button>
+        <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('svelte')">
+          Svelte
+        </button>
+        <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('qwik')">
+          Qwik
+        </button>
+        <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('solid')">
+          Solid
+        </button>
+        <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('astro')">
+          Astro
+        </button>
+        <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('react-native')">
+          React Native
+        </button>
         <button class="btn small mr-1 mb-1 opacity-75" @click="PackSvgs('json')">
           JSON
         </button>

--- a/src/utils/svg/helpers.ts
+++ b/src/utils/svg/helpers.ts
@@ -7,7 +7,7 @@ import { HtmlToJSX } from './htmlToJsx'
 import { getSvg } from './loader'
 import { prettierCode } from './prettier'
 
-export type PackType = 'svg' | 'tsx' | 'jsx' | 'vue' | 'json'
+export type PackType = 'svg' | 'tsx' | 'jsx' | 'vue' | 'vue-tsc' | 'solid' | 'qwik' | 'svelte' | 'astro' | 'react-native' | 'json'
 
 export function normalizeZipFleName(svgName: string): string {
   return svgName.replace(':', '-')

--- a/src/utils/svg/helpers.ts
+++ b/src/utils/svg/helpers.ts
@@ -7,7 +7,7 @@ import { HtmlToJSX } from './htmlToJsx'
 import { getSvg } from './loader'
 import { prettierCode } from './prettier'
 
-export type PackType = 'svg' | 'tsx' | 'jsx' | 'vue' | 'vue-tsc' | 'solid' | 'qwik' | 'svelte' | 'astro' | 'react-native' | 'json'
+export type PackType = 'svg' | 'tsx' | 'jsx' | 'vue' | 'solid' | 'qwik' | 'svelte' | 'astro' | 'react-native' | 'json'
 
 export function normalizeZipFleName(svgName: string): string {
   return svgName.replace(':', '-')

--- a/src/utils/worker/index.ts
+++ b/src/utils/worker/index.ts
@@ -4,15 +4,7 @@ import type { CollectionInfo } from '../../data'
 import type { PackType } from '../svg'
 import type { PackOperation, WorkerPackMessage } from './types'
 import { downloadZip } from 'client-zip'
-import {
-  getSvg,
-  LoadIconSvgs,
-  normalizeZipFleName,
-  SvgToJSX,
-  SvgToTSX,
-  SvgToVue,
-  toComponentName,
-} from '../svg'
+import { getSvg, LoadIconSvgs, normalizeZipFleName, SvgToAstro, SvgToJSX, SvgToQwik, SvgToReactNative, SvgToSolid, SvgToSvelte, SvgToTSX, SvgToVue, toComponentName } from '../svg'
 
 globalThis.onmessage = async (event: MessageEvent<WorkerPackMessage<PackOperation>>) => {
   const message = event.data
@@ -149,6 +141,8 @@ async function* PreparePackZip(
     return
   }
 
+  const ext = (type === 'solid' || type === 'qwik' || type === 'react-native') ? 'tsx' : type
+
   for (const name of icons) {
     if (!name)
       continue
@@ -165,6 +159,21 @@ async function* PreparePackZip(
       case 'jsx':
         content = await SvgToJSX(svg, componentName, false)
         break
+      case 'svelte':
+        content = SvgToSvelte(svg)
+        break
+      case 'astro':
+        content = SvgToAstro(svg)
+        break
+      case 'qwik':
+        content = await SvgToQwik(svg, componentName, false)
+        break
+      case 'react-native':
+        content = await SvgToReactNative(svg, componentName, false)
+        break
+      case 'solid':
+        content = await SvgToSolid(svg, componentName, false)
+        break
       case 'tsx':
         content = await SvgToTSX(svg, componentName, false)
         break
@@ -173,7 +182,7 @@ async function* PreparePackZip(
     }
 
     yield {
-      name: `${componentName}.${type}`,
+      name: `${componentName}.${ext}`,
       input: new Blob([content], { type: 'text/plain' }),
     }
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Added missing frameworks to the Download Zip option in the Bag, using the same list in the IconDetail.vue component excluding PNG format.

Applied same logic for file extension used in download function in the web worker.

### Linked Issues

resolves #370


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

![imagen](https://github.com/user-attachments/assets/c315208c-80c5-4512-b2e9-2f5e18ffb1a2)

